### PR TITLE
Added a plan, made it work...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,12 @@ class p9_instance_setup (
   Boolean $set_zsh = true,
   ) {
 
+  include ntp
+
+  class { 'timezone':
+    timezone => 'America/Los_Angeles',
+  }
+
   user { $test_user:
     ensure           => "present",
     home             => "/home/$test_user",
@@ -32,24 +38,6 @@ class p9_instance_setup (
     source  => "/home/centos/.ssh/authorized_keys",
     replace => true,
   }
-
-#  if $copy_fog {
-#    file { "fog":
-#      path   => "/home/$test_user/.fog",
-#      owner  => $test_user,
-#      group  => $test_user,
-#      source => "/home/centos/.fog",
-#    }
-#  }
-#  
-#  if $copy_tmux_conf {
-#    file { "tmux_conf":
-#      path   => "/home/$test_user/.tmux.conf",
-#      owner  => $test_user,
-#      group  => $test_user,
-#      source => "/home/centos/.tmux.conf",
-#    }
-#  }
 
   class { "sudo": }
   sudo::conf { "centos":
@@ -77,8 +65,10 @@ class p9_instance_setup (
   }
 
   if $set_zsh {
-    ohmyzsh::install { $test_user: set_sh => true }
-    ohmyzsh::plugins { $test_user: plugins => ['git', 'history', 'vi-mode'] }
+    p9_instance_setup::set_zsh { "$test_user zsh":
+      test_user => "$test_user",
+      require => User[$test_user],
+    }
   }
 
   include nginx

--- a/manifests/set_zsh.pp
+++ b/manifests/set_zsh.pp
@@ -1,0 +1,15 @@
+# A description of what this class does
+#
+# @summary A short summary of the purpose of this class
+#
+# @example
+#   include set_zsh
+class p9_instance_setup::set_zsh (
+  String $test_user = "tester",
+  ) {
+
+  ohmyzsh::install { $test_user: 
+    set_sh => true,
+  }
+  ohmyzsh::plugins { $test_user: plugins => ['git', 'history', 'vi-mode'] }
+}

--- a/plans/setup_instance.pp
+++ b/plans/setup_instance.pp
@@ -1,0 +1,90 @@
+plan p9_instance_setup::setup_instance (
+     TargetSpec $nodes,
+     String $instance_username = "tester",
+   ) {
+
+
+  $result_whoami = run_command('whoami',"localhost",'_catch_errors' => true)
+  $running_user = $result_whoami.first.value[stdout].strip
+#  notice("Using running bolt is $running_user")
+
+  $result_pwd = run_command('echo $HOME',"localhost",'_catch_errors' => true)
+  $home_dir = $result_pwd.first.value[stdout].strip
+#  notice("home_dir is $home_dir")
+
+  # Install the puppet-agent package if Puppet is not detected.
+  # Copy over custom facts from the Bolt modulepath.
+  # Run the `facter` command line tool to gather node information.
+  $nodes.apply_prep
+
+  # Compile the manifest block into a catalog
+  apply($nodes) {
+    class { 'p9_instance_setup':
+      test_user => $instance_username,
+      set_zsh => false,
+    }
+  }
+
+  #currently has to be run seperately...
+  #if run at the same time, errs about failing to set user shell because zsh isn't installed yet...
+  #which it shouldn't be trying to set in the first place since zsh "requires" the user already be created
+  apply($nodes) {
+    class { 'p9_instance_setup::set_zsh':
+      test_user => $instance_username,
+    }
+  }
+
+  upload_file("$home_dir/.fog","/home/centos/.fog",$nodes)
+  upload_file("$home_dir/.fog","/home/$instance_username/.fog",$nodes)
+  upload_file("$home_dir/.tmux.conf","/home/centos/.tmux.conf",$nodes)
+  upload_file("$home_dir/.tmux.conf","/home/$instance_username/.tmux.conf",$nodes)
+  run_command("rm -rf /home/centos/ssh_temp",$nodes)
+  upload_file("$home_dir/.ssh","/home/centos/ssh_temp",$nodes)
+
+  apply($nodes) {
+    file { 'centos ssh_temp':
+      path  => '/home/centos/ssh_temp',
+      owner => 'centos',
+      group => 'centos',
+      recurse => true,
+    }
+  }
+
+  run_command("cp /home/centos/ssh_temp/* /home/centos/.ssh/",$nodes)
+  run_command("cp -p /home/centos/ssh_temp/* /home/$instance_username/.ssh/",$nodes)
+
+  apply($nodes) {
+    file { 'centos fog':
+      path  => '/home/centos/.fog',
+      owner => 'centos',
+      group => 'centos',
+    }
+    file { 'centos tmux.conf':
+      path  => '/home/centos/.tmux.conf',
+      owner => 'centos',
+      group => 'centos',
+    }
+    file { 'centos ssh':
+      path  => '/home/centos/.ssh',
+      owner => 'centos',
+      group => 'centos',
+      recurse => true,
+    }
+    file { 'user fog':
+      path  => "/home/$instance_username/.fog",
+      owner => "$instance_username",
+      group => "$instance_username",
+    }
+    file { 'user tmux.conf':
+      path  => "/home/$instance_username/.tmux.conf",
+      owner => "$instance_username",
+      group => "$instance_username",
+    }
+    file { 'user ssh':
+      path  => "/home/$instance_username/.ssh",
+      owner => "$instance_username",
+      group => "$instance_username",
+      recurse => true,
+    }
+  }
+}


### PR DESCRIPTION
Added a plan that uses the module to setup the box, but also copies up fog, tmux.conf and .ssh files so that the account is more usable.

Had to split the zsh stuff out.. keeping it in the same class didn't work.  For some reason even though the zsh class required the user... the user creation failed because it was trying to set the shell to zsh... which it shouldn't do.
the module still works, but reuiqres running twice to work... which is lame.