### PR TITLE
(SLV-379) Copy ssh dir recursively

### DIFF
--- a/plans/setup_instance.pp
+++ b/plans/setup_instance.pp
@@ -56,8 +56,9 @@ plan p9_instance_setup::setup_instance (
     }
   }
 
-  run_command("cp /home/centos/ssh_temp/* /home/centos/.ssh/",$nodes)
-  run_command("cp -p /home/centos/ssh_temp/* /home/$username/.ssh/",$nodes)
+  run_command("cp -r /home/centos/ssh_temp/* /home/centos/.ssh/",$nodes)
+  run_command("cp -rp /home/centos/ssh_temp/* /home/$username/.ssh/",$nodes)
+  run_command("rm -rf /home/centos/ssh_temp",$nodes)
 
   apply($nodes) {
     file { 'centos fog':

--- a/plans/setup_instance.pp
+++ b/plans/setup_instance.pp
@@ -58,6 +58,8 @@ plan p9_instance_setup::setup_instance (
 
   run_command("cp -r /home/centos/ssh_temp/* /home/centos/.ssh/",$nodes)
   run_command("cp -rp /home/centos/ssh_temp/* /home/$username/.ssh/",$nodes)
+  run_command("chmod 700 /home/centos/.ssh",$nodes)
+  run_command("chmod 700 /home/$username/.ssh",$nodes)
   run_command("rm -rf /home/centos/ssh_temp",$nodes)
 
   apply($nodes) {


### PR DESCRIPTION
This commit updates the copy commands for the ssh_temp dir to copy
them recursively.  A command to delete the ssh_temp dir after the
copy is complete has also been added to clean up the extra copy.