### PR TITLE
(SLV-435) Install bolt on host via setup plan

### DIFF
--- a/plans/setup_instance.pp
+++ b/plans/setup_instance.pp
@@ -24,6 +24,13 @@ plan p9_instance_setup::setup_instance (
   # Run the `facter` command line tool to gather node information.
   $nodes.apply_prep
 
+  # Install puppet-bolt
+  apply($nodes) {
+    package { 'puppet-bolt' :
+      ensure => 'present',
+    }
+  }
+
   # Compile the manifest block into a catalog
   apply($nodes) {
     class { 'p9_instance_setup::core':


### PR DESCRIPTION
This commit adds the installation of puppet-bolt on the target
host using the `setup_instance` plan.  Since `apply_prep` is used
to install puppet previously, the necessary package repo is already
available on the host.  All that is needed is to ensure that the
package is installed via `puppet apply`.